### PR TITLE
eclass/gentoo.eclass : Create distfiles/geek/gentoo if it does not exist

### DIFF
--- a/eclass/gentoo.eclass
+++ b/eclass/gentoo.eclass
@@ -70,6 +70,7 @@ gentoo_src_unpack() {
 	shift
 
 	test -d "${CWD}" >/dev/null 2>&1 || mkdir -p "${CWD}"
+	test -d "${CSD}" >/dev/null 2>&1 || mkdir -p "${CSD}"
 	cd "${CSD}" || die "${RED}cd ${CSD} failed${NORMAL}"
 
 	test -d "${GENTOO_VER}" >/dev/null 2>&1 || mkdir -p "${GENTOO_VER}"


### PR DESCRIPTION
I did not see this, as I already had this directory from previous
installations. So most users wouldn't notice until they had that
directory removed, or start completely new with the gentoo USE flag.

However, it must be created of course. Originally this was created by
the full call to `git clone`, which is gone in favour of shallow clones.