### PR TITLE
geek-sources-4.1.1.ebuild: Took out bfq, uksm and zen, those do not y…

### DIFF
--- a/sys-kernel/geek-sources/geek-sources-4.1.1.ebuild
+++ b/sys-kernel/geek-sources/geek-sources-4.1.1.ebuild
@@ -9,7 +9,10 @@ KMV="$(echo $PV | cut -f 1-2 -d .)"
 KSV="$(echo $PV | cut -f 1-3 -d .)"
 
 AUFS_VER="${KMV}"
-BFQ_VER="${KMV}.0-v7r7"
+
+# 2015-07-01 :
+# Currently only up to 4.0
+#BFQ_VER="${KMV}.0-v7r7"
 
 # 2015-07-01 :
 # Currently only up to 3.19
@@ -23,8 +26,10 @@ BFQ_VER="${KMV}.0-v7r7"
 
 ICE_VER="for-linux-head-${KMV}.0-rc8-2015-06-17"
 FEDORA_VER="f22"
+
 #GRSEC_VER="3.1-${KSV}-201504190814" # 19/04/15 08:14
 #GRSEC_SRC="http://grsecurity.net/test/grsecurity-${GRSEC_VER}.patch"
+
 LQX_VER="${KSV}-1"
 MAGEIA_VER="releases/${KSV}/1.mga5"
 
@@ -41,10 +46,16 @@ MAGEIA_VER="releases/${KSV}/1.mga5"
 
 # RT_VER="${KSV}-rt17"
 SUSE_VER="stable"
-UKSM_VER="0.1.2.3"
-UKSM_NAME="uksm-${UKSM_VER}-for-v3.18"
 
-SUPPORTED_USES="aufs bfq brand -build -deblob fedora ice gentoo pf suse symlink uksm zen"
+# 2015-07-01 :
+# Only supported up to 4.0, yet.
+#UKSM_VER="0.1.2.4"
+#UKSM_NAME="uksm-${UKSM_VER}-beta-for-linux-v4.0"
+
+# 2015-07-01 :
+# ZEN is still empty for 4.1
+
+SUPPORTED_USES="aufs brand -build -deblob fedora ice gentoo pf suse symlink"
 
 inherit geek-sources
 


### PR DESCRIPTION
…et support kernel 4.1

Now that the new ebuild is up, I could test it properly.

Unfortunately bfq, UKSM and ZEN do not yet support 4.1, so I took them out.

(Had to see bfq and uksm, and I accidently overlooked that the zen patch is empty in my pre-tests, sorry!)